### PR TITLE
Fixed unable to edit user stories multiple times issue

### DIFF
--- a/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/widgets/UserStoryWidget.java
+++ b/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/widgets/UserStoryWidget.java
@@ -78,5 +78,8 @@ public class UserStoryWidget extends JPanel implements BaseComponent {
                 desc,
                 new CustomConstraints(
                         3, 0, GridBagConstraints.WEST, 0.7, 0.0, GridBagConstraints.HORIZONTAL));
+
+        revalidate();
+        repaint();        
     }
 }


### PR DESCRIPTION
Issue: #8 Allow User Stories to be edited multiple times

I added revalidate() and repaint() to the init() method in UserStoryWidget.java. These methods ensure that the panel's layout is re-calculated and the UI is repainted, allowing the widget to properly reinitialize and handle subsequent edit actions. This enables the edit form to open multiple times without any issues.