### PR TITLE
Fixed issue 64 user story list not updated

### DIFF
--- a/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/panels/UserStoryListPane.java
+++ b/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/panels/UserStoryListPane.java
@@ -83,6 +83,8 @@ public class UserStoryListPane extends JFrame implements BaseComponent {
                                                         1.0,
                                                         0.1,
                                                         GridBagConstraints.HORIZONTAL));
+                                        revalidate();
+                                        repaint();
                                     }
                                 });
                     }

--- a/src/test/java/com/groupesan/project/java/scrumsimulator/mainpackage/impl/UserStoryTest.java
+++ b/src/test/java/com/groupesan/project/java/scrumsimulator/mainpackage/impl/UserStoryTest.java
@@ -15,7 +15,7 @@ public class UserStoryTest {
     public void setup() {
         myUserStory =
                 UserStoryFactory.getInstance()
-                        .createNewUserStory("predefinedUS1", "description1", 1.0);
+                        .createNewUserStory("predefinedUS1", "description1", 1.0, 1.0);
     }
 
     @Test


### PR DESCRIPTION
Issue #64 Story update on adding new story

The user story list pane is not getting when a new story is added. In order to fix this I added revalidate() and repaint() to the windowClosed() method of new user story widget in UserStoryListPane.java. These methods ensure that the panel's layout is re-calculated and the UI is repainted, allowing the widget to properly reinitialize and handle subsequent add actions. 